### PR TITLE
Move MainPage.xaml and related into Views folder

### DIFF
--- a/App/AppShell.xaml
+++ b/App/AppShell.xaml
@@ -8,7 +8,7 @@
 
     <ShellContent
         Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
+        ContentTemplate="{DataTemplate local:Views.MainPage}"
+        Route="Views/MainPage" />
 
 </Shell>

--- a/App/Views/MainPage.xaml
+++ b/App/Views/MainPage.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="App.MainPage">
+             x:Class="App.Views.MainPage">
 
     <ScrollView>
         <VerticalStackLayout

--- a/App/Views/MainPage.xaml.cs
+++ b/App/Views/MainPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace App
+﻿namespace App.Views
 {
     public partial class MainPage : ContentPage
     {


### PR DESCRIPTION
Closes https://github.com/Nemesnyky/studennyk/issues/19

This would match the MVC structure. Now all the pages-related code should go under Views folder and have App.Views namespace.